### PR TITLE
fixing a typo in the new testing assertions

### DIFF
--- a/assertions.go
+++ b/assertions.go
@@ -70,7 +70,7 @@ func (h *requiredHeaderValue) Assert(r *http.Request) error {
 
 // Log prints a testing info log for the requiredHeaderValue Assertor
 func (h *requiredHeaderValue) Log(t testing.TB) {
-	t.Logf("Testing request for required header value [%s: %s]", h.Key, h.ExpectedValue)
+	t.Logf("Testing request for a required header value [%s: %s]", h.Key, h.ExpectedValue)
 }
 
 // Error prints a testing error for the requiredHeaderValue Assertor
@@ -126,7 +126,7 @@ func (q *requiredQueryValue) Assert(r *http.Request) error {
 
 // Log prints a testing info log for the requiredQueryValue Assertor
 func (q *requiredQueryValue) Log(t testing.TB) {
-	t.Logf("Testing request for required query parameter value [%s: %s]", q.Key, q.ExpectedValue)
+	t.Logf("Testing request for a required query parameter value [%s: %s]", q.Key, q.ExpectedValue)
 }
 
 // Error prints a testing error for the requiredQueryValue Assertor
@@ -161,7 +161,7 @@ func (b *requiredBody) Assert(r *http.Request) error {
 
 // Log prints a testing info log for the requiredBody Assertor
 func (b *requiredBody) Log(t testing.TB) {
-	t.Log("Testing request for required a required body")
+	t.Log("Testing request for a required body value")
 }
 
 // Error prints a testing error for the requiredBody Assertor

--- a/assertions.go
+++ b/assertions.go
@@ -147,7 +147,7 @@ func (b *requiredBody) Assert(r *http.Request) error {
 
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		return fmt.Errorf("error reading the request body: %w", err)
+		return fmt.Errorf("error reading the request body: %s", err.Error())
 	}
 
 	if !bytes.EqualFold(b.ExpectedBody, body) {

--- a/assertions_test.go
+++ b/assertions_test.go
@@ -315,7 +315,7 @@ func TestAssertors_Log(t *testing.T) {
 				buf: &bytes.Buffer{},
 			},
 			assertor: &requiredHeaderValue{Key: "test-key", ExpectedValue: "test-value"},
-			expected: "Testing request for required header value [test-key: test-value]",
+			expected: "Testing request for a required header value [test-key: test-value]",
 		},
 		{
 			name: "requiredQueries Log should log the expected output when called",
@@ -331,7 +331,7 @@ func TestAssertors_Log(t *testing.T) {
 				buf: &bytes.Buffer{},
 			},
 			assertor: &requiredQueryValue{Key: "test-key", ExpectedValue: "test-value"},
-			expected: "Testing request for required query parameter value [test-key: test-value]",
+			expected: "Testing request for a required query parameter value [test-key: test-value]",
 		},
 		{
 			name: "requiredBody Log should log the expected output when called",
@@ -339,7 +339,7 @@ func TestAssertors_Log(t *testing.T) {
 				buf: &bytes.Buffer{},
 			},
 			assertor: &requiredBody{},
-			expected: "Testing request for required a required body\n",
+			expected: "Testing request for a required body value\n",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
# What
- I noticed there was a typo in the recent changes around testing assertions, this updates the values and the affected tests.