### PR TITLE
Creating a new CustomAssertor type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: go
 
 go:
-  - 1.12.x
   - 1.13.x
+  - 1.14.x
+  - 1.15.x
+  - 1.16.x
   - master
 
 script:

--- a/README.md
+++ b/README.md
@@ -45,13 +45,14 @@ supported assertions are:
 * The expected body of your request
 
 [WithTesting](https://godoc.org/github.com/maxcnunes/httpfake#WithTesting) **must** be provided as a server
-option when creating the test server if intend to set request assertions. Failing to set the option
+option when creating the test server if you intend to set request assertions. Failing to set the option
 when using request assertions will result in a panic.
 
 ### Custom Assertions
 
-You can also provide your own request assertions by creating a type that implements the
-[Assertor interface](https://godoc.org/github.com/maxcnunes/httpfake#Assertor). The `Assertor.Log` method will be
+You can also provide your own assertions by creating a type that implements the
+[Assertor interface](https://godoc.org/github.com/maxcnunes/httpfake#Assertor) or utilizing the
+[CustomAssertor function type](https://pkg.go.dev/github.com/maxcnunes/httpfake#CustomAssertor). The `Assertor.Log` method will be
 called for each assertion before it's processed. The `Assertor.Error` method will only be called if the
 `Assertor.Assert` method returns an error.
 

--- a/assertions.go
+++ b/assertions.go
@@ -168,3 +168,22 @@ func (b *requiredBody) Log(t testing.TB) {
 func (b *requiredBody) Error(t testing.TB, err error) {
 	t.Errorf(assertErrorTemplate, err)
 }
+
+// CustomAssertor provides a function signature that implements the Assertor interface. This allows for
+// adhoc creation of a custom assertion for use with the AssertCustom assertor.
+type CustomAssertor func(r *http.Request) error
+
+// Assert runs the CustomAssertor assertion against the provided request
+func (c CustomAssertor) Assert(r *http.Request) error {
+	return c(r)
+}
+
+// Log prints a testing info log for the CustomAssertor
+func (c CustomAssertor) Log(t testing.TB) {
+	t.Log("Testing request with a custom assertor")
+}
+
+// Error prints a testing error for the CustomAssertor
+func (c CustomAssertor) Error(t testing.TB, err error) {
+	t.Errorf(assertErrorTemplate, err)
+}

--- a/assertions_test.go
+++ b/assertions_test.go
@@ -266,6 +266,36 @@ func TestAssertors_Assert(t *testing.T) {
 			},
 			expectedErr: "error reading the request body; the request body is nil",
 		},
+		{
+			name: "CustomAssertor should execute the custom assertor as expected",
+			assertor: CustomAssertor(func(r *http.Request) error {
+				return nil
+			}),
+			requestBuilder: func() (*http.Request, error) {
+				testReq, err := http.NewRequest(http.MethodGet, "http://fake.url", nil)
+				if err != nil {
+					return nil, err
+				}
+
+				return testReq, nil
+			},
+			expectedErr: "",
+		},
+		{
+			name: "CustomAssertor should execute the custom assertor and return an error as expected",
+			assertor: CustomAssertor(func(r *http.Request) error {
+				return errors.New("custom assertor error")
+			}),
+			requestBuilder: func() (*http.Request, error) {
+				testReq, err := http.NewRequest(http.MethodGet, "http://fake.url", nil)
+				if err != nil {
+					return nil, err
+				}
+
+				return testReq, nil
+			},
+			expectedErr: "custom assertor error",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -341,6 +371,16 @@ func TestAssertors_Log(t *testing.T) {
 			assertor: &requiredBody{},
 			expected: "Testing request for a required body value\n",
 		},
+		{
+			name: "CustomAssertor Log should log the expected output when called",
+			mockTester: &mockTester{
+				buf: &bytes.Buffer{},
+			},
+			assertor: CustomAssertor(func(r *http.Request) error {
+				return nil
+			}),
+			expected: "Testing request with a custom assertor\n",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -399,6 +439,16 @@ func TestAssertors_Error(t *testing.T) {
 				buf: &bytes.Buffer{},
 			},
 			assertor: &requiredBody{},
+			expected: "assertion error: test error",
+		},
+		{
+			name: "CustomAssertor Log should log the expected output when called",
+			mockTester: &mockTester{
+				buf: &bytes.Buffer{},
+			},
+			assertor: CustomAssertor(func(r *http.Request) error {
+				return nil
+			}),
 			expected: "assertion error: test error",
 		},
 	}


### PR DESCRIPTION
# What
- This PR adds a new `CustomAssertor` type for use with the `AssertCustom` assertor. This allows users to construct a custom assertion on the fly without needing to create an Assertor type.

# Example
```golang
mockServer.NewHandler().
	Post("/path").
	AssertCustom(httpfake.CustomAssertor(func(r *http.Request) error {
		b, err := ioutil.ReadAll(r.Body)
		if err != nil {
			return errors.New("invalid request body")
		}

		var payload SamplePayload
		if err = json.Unmarshal(b, &payload); err != nil {
			return errors.New("unable to unmarshal request body")
		}

		if !reflect.DeepEqual(expected, payload.Data) {
			return errors.New("request does not have the expected body")
		}

		return nil
	})).
	Reply(200)
```