### PR TITLE
switch to using testing.TB vs a concrete testing state type

### DIFF
--- a/httpfake.go
+++ b/httpfake.go
@@ -18,7 +18,7 @@ import (
 type HTTPFake struct {
 	Server          *httptest.Server
 	RequestHandlers []*Request
-	t               *testing.T
+	t               testing.TB
 }
 
 // ServerOption provides a functional signature for providing configuration options to the fake server
@@ -26,13 +26,13 @@ type ServerOption func(opts *ServerOptions)
 
 // ServerOptions a configuration object for the fake test server
 type ServerOptions struct {
-	t *testing.T
+	t testing.TB
 }
 
 // WithTesting returns a configuration function that allows you to configure the testing object on the fake server.
 // The testing object is utilized for assertions set on the request object and will throw a testing error if an
 // endpoint is not called.
-func WithTesting(t *testing.T) ServerOption {
+func WithTesting(t testing.TB) ServerOption {
 	return func(opts *ServerOptions) {
 		opts.t = t
 	}

--- a/request.go
+++ b/request.go
@@ -78,7 +78,7 @@ func (r *Request) method(method, path string) *Request {
 	return r
 }
 
-func (r *Request) runAssertions(t *testing.T, testReq *http.Request) {
+func (r *Request) runAssertions(t testing.TB, testReq *http.Request) {
 	for _, assertor := range r.assertions {
 		assertor.Log(t)
 		if err := assertor.Assert(testReq); err != nil {


### PR DESCRIPTION
# What
- addresses feedback in #6 by moving to the [testing.TB interface](https://golang.org/pkg/testing/#TB)